### PR TITLE
Don't prevent POSTs for unrelated URLs registered by another module.

### DIFF
--- a/server.js
+++ b/server.js
@@ -325,15 +325,7 @@ Server.prototype = new function () {
         )
       );
 
-    if (request.method != 'HEAD' && request.method != 'GET') {
-      // I don't know how to do this.
-      response.writeHead(405, {
-        'allow': 'HEAD, GET'
-      , 'content-type': 'text/plain; charset=utf-8'
-      });
-      response.write("405: Only the HEAD or GET methods are allowed.");
-      response.end();
-    } else if (!modulePath) {
+    if (!modulePath) {
       if (next) {
         next();
       } else {
@@ -343,6 +335,14 @@ Server.prototype = new function () {
         response.write("404: The requested resource could not be found.");
         response.end();
       }
+    } else if (request.method != 'HEAD' && request.method != 'GET') {
+      // I don't know how to do this.
+      response.writeHead(405, {
+        'allow': 'HEAD, GET'
+      , 'content-type': 'text/plain; charset=utf-8'
+      });
+      response.write("405: Only the HEAD or GET methods are allowed.");
+      response.end();
     } else if (!('callback' in url.query)) {
       // I respond with a straight-forward proxy.
       var resourceURI = this._resourceURIForModulePath(modulePath);


### PR DESCRIPTION
Currently, the yajsml server checks for GET or HEAD before it checks if it's actually handling the request. If it's going to pass on the request by calling next(), it shouldn't be doing this check.